### PR TITLE
fix: bind to 127.0.0.1 by default, add --host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ kiro-history -p 3000
 
 # Don't open browser automatically
 kiro-history --no-open
+
+# Listen on all interfaces (accessible from other devices on your network)
+kiro-history --host 0.0.0.0
 ```
 
 ### Source Selection
@@ -96,6 +99,7 @@ kiro-history --source ide ~/path/to/kiro.kiroagent
 | `path` | Custom path to database file (CLI) or sessions directory (IDE) | Auto-detected |
 | `-s, --source <type>` | Source type: `cli`, `ide`, or `auto` | `auto` |
 | `-p, --port <number>` | Port to run the server on | Random available port |
+| `--host <address>` | Host address to bind to | `127.0.0.1` |
 | `--no-open` | Don't open browser automatically | Opens browser |
 | `-V, --version` | Show version number | - |
 | `-h, --help` | Show help | - |

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -77,8 +77,9 @@ export async function main(): Promise<void> {
     .argument('[path]', 'Custom path to the database file (CLI) or sessions directory (IDE)')
     .option('-p, --port <number>', 'Port to run the server on (default: auto)')
     .option('-s, --source <type>', 'Source type: cli, ide, or auto (default: auto)', 'auto')
+    .option('--host <address>', 'Host address to bind to (default: 127.0.0.1)', '127.0.0.1')
     .option('--no-open', 'Do not open browser automatically')
-    .action(async (userPath?: string, options?: { port?: string; open?: boolean; source?: string }) => {
+    .action(async (userPath?: string, options?: { port?: string; open?: boolean; source?: string; host?: string }) => {
       const sourceOption = (options?.source || 'auto') as SourceType;
       const source = sourceOption === 'auto' ? detectSource() : sourceOption as 'cli' | 'ide';
 
@@ -162,6 +163,7 @@ export async function main(): Promise<void> {
       const { port, close: closeServer } = await startServer({ 
         reader, 
         port: requestedPort,
+        hostname: options?.host,
         sourceType: source,
         alternateReader,
         alternateSourceType,

--- a/server/index.ts
+++ b/server/index.ts
@@ -179,14 +179,16 @@ export function createApp(options: ServerOptions): Hono {
 }
 
 export async function startServer(
-  options: ServerOptions & { port?: number }
+  options: ServerOptions & { port?: number; hostname?: string }
 ): Promise<{ port: number; close: () => void }> {
   const app = createApp(options);
+  const hostname = options.hostname || '127.0.0.1';
 
   return new Promise((resolve) => {
     const server = serve({
       fetch: app.fetch,
       port: options.port || 0, // Use specified port or let OS assign
+      hostname,
     }, (info) => {
       resolve({
         port: info.port,


### PR DESCRIPTION
Fixes #11.

Previously the server listened on 0.0.0.0 (all interfaces) by default, exposing conversation history to the local network without the user's knowledge. This change defaults the listen address to 127.0.0.1 (localhost only) so the server is not accessible from other devices.

Users who want network access can opt in with:

  kiro-history --host 0.0.0.0

Changes:
- server/index.ts: startServer() accepts a hostname parameter, defaults to '127.0.0.1', passes it to @hono/node-server serve().
- server/cli.ts: Added --host <address> CLI option (default: 127.0.0.1).
- README.md: Documented the --host option in the options table and added a usage example.